### PR TITLE
Add Topping D90 to supported hardware list

### DIFF
--- a/content/audio_hardware/_index.md
+++ b/content/audio_hardware/_index.md
@@ -80,6 +80,7 @@ RoPieee supports, besides DoP (DSD over PCM), native DSD on the following USB DA
 * OPPO Sonica
 * PS Audio NuWave DAC
 * TEAC UD-503
+* Topping D90
 * Topping DX7s
 * Singxer F-1 converter board
 * SMSL M8A


### PR DESCRIPTION
I'm not sure if this sort of contribution is welcomed, but I have confirmed that the Topping D90 USB DAC supports native DSD with Ropieeee.  See also: [Related forum post](https://community.roonlabs.com/t/ropieee-topping-d90-usb-dac/96779/3?u=nugget)